### PR TITLE
Split of priority_idx and `q_name` column addition

### DIFF
--- a/pq/create.sql
+++ b/pq/create.sql
@@ -12,9 +12,15 @@ CREATE TABLE %(name)s (
 
 end $$ language plpgsql;
 
-create index priority_idx on %(name)s
-    (schedule_at nulls first, expected_at nulls first)
-    where dequeued_at is null;
+create index priority_idx_%(name)s on %(name)s
+    (schedule_at nulls first, expected_at nulls first, q_name)
+    where dequeued_at is null
+          and q_name = '%(name)s';
+
+create index priority_idx_no_%(name)s on %(name)s
+    (schedule_at nulls first, expected_at nulls first, q_name)
+    where dequeued_at is null
+          and q_name != '%(name)s';
 
 drop function if exists pq_notify() cascade;
 


### PR DESCRIPTION
Added  q_name column with %(name)s filtering, for addressing performance issues. There were a large amount of indexes blocks locked as there were no entry for `q_name`. Also, we split the q_name in the index as %(name)s could reach ~40% of the table.
Unfortunately, the EXPLAINS does not show a very different plan, although the CPU usage decreases nearly down 20% on dispatching.

Pre-index:

```
->  Index Scan using priority_idx on tasks tasks_1  (cost=0.43..270151.35 rows=595759 width=157)
```

Post-Index:

```
->  Index Scan using tasks_schedule_at_expected_at_q_name_idx on tasks tasks_1  (cost=0.42..243168.44 rows=647347 width=157)
```
